### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an error message

### DIFF
--- a/src/main/java/net/icewheel/energy/api/rest/controller/ScheduleApiController.java
+++ b/src/main/java/net/icewheel/energy/api/rest/controller/ScheduleApiController.java
@@ -111,7 +111,8 @@ public class ScheduleApiController {
 		}
 		catch (ScheduleImportException e) {
 			// This catches validation errors from the service layer.
-			return ResponseEntity.badRequest().body(e.getMessage());
+			log.warn("Schedule import validation failed", e);
+			return ResponseEntity.badRequest().body("Import failed: The uploaded schedule file contains invalid data. Please check your file and try again.");
 		}
 		catch (IOException e) {
 			// This can happen if the file is corrupt or not valid JSON.


### PR DESCRIPTION
Potential fix for [https://github.com/icewheel-oss/icewheel-energy/security/code-scanning/2](https://github.com/icewheel-oss/icewheel-energy/security/code-scanning/2)

To fix this information exposure vulnerability, we should replace the detailed exception message sent via `e.getMessage()` with a generic, non-revealing error message that does not leak internal state. For developer diagnostics, we should log the original exception and message server-side using the configured logging framework (`Slf4j` is already present). 

Specifically, in `ScheduleApiController.java`, inside the catch block for `ScheduleImportException`, replace the code so that:
- The exception (including its message and stack trace) is logged using `log.warn()` or `log.error()`.
- The HTTP response body contains a neutral message such as "Import failed: The uploaded schedule file contains invalid data." or similar, which does not leak exception content.

No new dependencies are needed since logging via Slf4j is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
