### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/icewheel-oss/icewheel-energy/security/code-scanning/1](https://github.com/icewheel-oss/icewheel-energy/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` key to the workflow, either at the root level (which sets the default for all jobs in the workflow) or at the job level (for more fine-grained control). In this particular workflow, no steps require write or extended permissions (e.g., to issues, pull requests, or secrets), so setting `permissions: contents: read` at the root level is sufficient and adheres to the principle of least privilege.

Specifically, add the following block beneath the `name:` field and above the `on:` block, i.e., between line 9 (`name: Java CI with Maven`) and line 11 (`on:`). No new imports or method definitions are needed. No additional dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
