### PR TITLE
fix(scheduler): Prevent weather scheduler creating tasks on inactive …

### DIFF
--- a/src/main/java/net/icewheel/energy/application/scheduling/WeatherAwareScheduler.java
+++ b/src/main/java/net/icewheel/energy/application/scheduling/WeatherAwareScheduler.java
@@ -291,6 +291,14 @@ public class WeatherAwareScheduler {
 			stopExecutionTime = stopExecutionTime.plusDays(1);
 		}
 
+		// Why: This is the fix for the bug where a weather event on a Friday would schedule a "stop charge"
+		// event for Saturday morning, even if the schedule was only for Mon-Fri. This loop ensures
+		// that the stop event is pushed forward to the next valid day of the week according to the
+		// permanent schedule's configuration.
+		while (!onPeakSchedule.getDaysOfWeek().contains(stopExecutionTime.getDayOfWeek())) {
+			stopExecutionTime = stopExecutionTime.plusDays(1);
+		}
+
 		startChargeSchedule.setExpirationTime(stopExecutionTime.toInstant());
 		stopChargeSchedule.setExpirationTime(stopExecutionTime.toInstant());
 


### PR DESCRIPTION
…days

The WeatherAwareScheduler was creating temporary 'stop charge' schedules for the following day without validating if that day was part of the parent schedule's active days.

This caused an issue where a weather event on a Friday would incorrectly schedule a task for Saturday morning on a Monday-to-Friday schedule, leading to unexpected battery discharge over the weekend.

The fix introduces a check to ensure the 'stop charge' execution time is advanced to the next valid, active day as defined by the parent schedule's daysOfWeek configuration.